### PR TITLE
Change joda-time dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 
 dependencies {
     compile "org.yaml:snakeyaml:1.16"
-    compile "net.danlew:android.joda:2.9.0"
+    compile "joda-time:joda-time:2.9.1"
     testCompile "junit:junit:4.11"
     testCompile "org.hamcrest:hamcrest-junit:2.0.0.0"
     testCompile "org.mockito:mockito-core:2.0.+"


### PR DESCRIPTION
We should use the Java version of the Joda-Time lib. Otherwise, Faker won't compile when we build it as a Gradle dependency.