### PR TITLE
Fix RandomHelper (long) number 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 
-version = '1.2.8'
+version = '1.2.9'
 group = 'com.github.blocoio'
 
 sourceCompatibility = JavaVersion.VERSION_1_7

--- a/src/main/java/io/bloco/faker/helpers/RandomHelper.java
+++ b/src/main/java/io/bloco/faker/helpers/RandomHelper.java
@@ -28,7 +28,7 @@ public class RandomHelper {
     }
 
     public long number(long max) {
-        return Math.abs(random.nextLong()) % max;
+        return (max != 0) ? Math.abs(random.nextLong()) % max : 0;
     }
 
     public int numberByLength(int length) {

--- a/src/test/java/io/bloco/faker/helpers/RandomHelperTest.java
+++ b/src/test/java/io/bloco/faker/helpers/RandomHelperTest.java
@@ -1,0 +1,29 @@
+package io.bloco.faker.helpers;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.security.SecureRandom;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertThat;
+
+public class RandomHelperTest {
+
+    private RandomHelper randomHelper;
+    private SecureRandom random;
+
+    @Before
+    public void setUp() {
+        randomHelper = new RandomHelper();
+        random = new SecureRandom();
+    }
+
+    @Test
+    public void testNumber() {
+        assertThat(randomHelper.number((long) 0), is((long) 0));
+        assertThat(randomHelper.number(random.nextLong() + 1), not((long) 0));
+    }
+}
+


### PR DESCRIPTION
(long) number usages:

- (Random Helper class) **getRandomDate** - 0 is a valid value;
- (Number class) **hexadecimal** - impossible send 0 to (long) number;
- (Random Helper class) **range** - impossible send 0 to (long) number.